### PR TITLE
Add prefers-reduced-motion Media Query to Conditionally Disable Animations

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -147,6 +147,19 @@ img {
   to   { transform: rotate(360deg); }
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .donut {
+        animation: none;
+        -webkit-animation: none;
+        -moz-animation: none;
+        -ms-animation: none;
+    }
+
+    .sprinkles {
+        display: none;
+    }
+}
+
 /* Top Navigation - - - - - - - - - - */
 .navigation {
   background-color: #1C406C;


### PR DESCRIPTION
When a user visits the [donutjs.club](https://donutjs.club) website, they'll see a spinning donut and sprinkles raining down in the background. If that user suffers from a visually-triggered vestibular disorder or experiences discomfort from large-scale motion on screens, these animations may cause dizziness, nausea, headaches, or other symptoms. For more information, check out [this article by Val Head on A List Apart](https://alistapart.com/article/designing-safer-web-animation-for-motion-sensitivity).

Some operating systems offer an accessibility setting to reduce motion system-wide. On macOS, you can enable this in System Preferences > Accessibility > Display:

<img width="780" alt="reduce-motion" src="https://user-images.githubusercontent.com/7659/43468613-4eb41606-9499-11e8-925a-2d48ded04027.png">

This PR adds a `prefers-reduced-motion` media query to the site CSS, to conditionally stop the spinning donut animation and hide the sprinkles animation when a user enables the "reduce motion" system accessibility feature.

One alternative to hiding the `.sprinkles` element would be to replace the use of `setInterval` with [Web Animations](https://drafts.csswg.org/web-animations/), for which some browsers offer global pause / stop controls.