### PR TITLE
Sprinkle Animation Improvements

### DIFF
--- a/js/sprinkles.js
+++ b/js/sprinkles.js
@@ -76,8 +76,9 @@ window.addEventListener('load', function(event) {
         }
       }
     })
+    window.requestAnimationFrame(draw)
   }
 
   // kick off the drawing loop
-  setInterval(draw, 33)
+  draw()
 });

--- a/js/sprinkles.js
+++ b/js/sprinkles.js
@@ -1,4 +1,4 @@
-window.addEventListener('load', function(event) {
+window.addEventListener('DOMContentLoaded', function(event) {
   var canvas = document.getElementById('sprinkles')
   var ctx = canvas.getContext('2d')
   var W = window.innerWidth


### PR DESCRIPTION
While investigating #71, I noticed a couple things in the `sprinkles.js` that could be changed to optimize the animation:

- Use `window.requestAnimationFrame` instead of `setInterval` for the draw loop. ([93.81% browser support](https://caniuse.com/#feat=requestanimationframe)
- Change `window.addEventListener` from `'load'` to `'DOMContentLoaded'`. This allows the sprinkles to start animating right away, whereas they currently wait for all resources to load first (at least for me, the `<iframe>` elements take an extra couple seconds). ([96.85% browser support](https://caniuse.com/#feat=domcontentloaded)

With these two changes, the sprinkles animation start immediately and run at 60fps (at least when I run it locally).